### PR TITLE
bugfix: オーディオバッファコピー処理を修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## Version 1.1.2
+
+- bugfix: correct copy sound buffer procedure
+
 ## Version 1.1.1
 
 - bugfix: invalid copy size (it does not become obvious)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ __IMPORTANT: Your Project's license must to GPLv3 if use it. (confirm the LICENS
 
 ```
 dependencies {
-    implementation 'com.suzukiplan:nes-emulator-android:1.1.1'
+    implementation 'com.suzukiplan:nes-emulator-android:1.1.2'
 }
 ```
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "1.1.1"
+def pomVersion = "1.1.2"
 
 android {
     compileSdkVersion 26
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 26
         versionCode 3
-        versionName "1.1.1"
+        versionName "1.1.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }

--- a/library/src/main/cpp/AndroidAudioFairy.hpp
+++ b/library/src/main/cpp/AndroidAudioFairy.hpp
@@ -18,16 +18,21 @@ struct SL {
     SLAndroidSimpleBufferQueueItf slBufQ;
 };
 
-class AndroidAudioFairy : public AudioFairy
-{
+class AndroidAudioFairy : public AudioFairy {
 public:
     AndroidAudioFairy(int sampling, int bit, int channel);
+
     ~AndroidAudioFairy();
-    int16_t buffer[65536];
+
+    int16_t buffer[4096];
     char emptyBuffer[1024];
+
     void lock();
+
     void unlock();
+
     static void callback(SLAndroidSimpleBufferQueueItf bq, void *c);
+
     bool isEnded() {
         return NULL == sl.slBufQ;
     }
@@ -38,7 +43,9 @@ private:
     int sampling;
     int bit;
     SLuint32 channel;
+
     int init_sl();
+
     int init_sl2();
 };
 


### PR DESCRIPTION
オーディオの再現性が本家（SDL版）と聴き比べたら何かマズイ感じだったので、本家処理に倣った形に修正する。
https://github.com/ledyba/Cycloa/blob/master/src/fairy/sdl/SDLAudioFairy.cpp
