### PR TITLE
change key code specification (destructive)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## Version 1.3.0 (destructive)
+
+- changed the specification of key code
+
 ## Version 1.2.3
 
 - added: `NESView#multipleTicks`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ __IMPORTANT: Your Project's license must to GPLv3 or compatible if use it. (conf
 
 ```
 dependencies {
-    implementation 'com.suzukiplan:nes-emulator-android:1.2.3'
+    implementation 'com.suzukiplan:nes-emulator-android:1.3.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,10 @@ dependencies {
     nesView?.load(romByteArray)
 
     // key calculator
-    val keyP1 = NESKey()
-    val keyP2 = NESKey()
+    val key = NESKey()
 
     // execute 1 frame
-    nesView?.tick(keyP1.code, keyP2.code)
+    nesView?.tick(key.code)
 ```
 
 > See the [example](test/src/main/java/com/suzukiplan/emulator/nes/test/MainActivity.kt)

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "1.2.3"
+def pomVersion = "1.3.0"
 
 android {
     compileSdkVersion 26
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 8
-        versionName "1.2.3"
+        versionCode 9
+        versionName "1.3.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }

--- a/library/src/main/java/com/suzukiplan/emulator/nes/core/Emulator.java
+++ b/library/src/main/java/com/suzukiplan/emulator/nes/core/Emulator.java
@@ -13,9 +13,9 @@ final class Emulator {
 
     public static native boolean loadRom(long contextId, byte[] rom);
 
-    public static native void tick(long contextId, int key1, int key2, Bitmap vram);
+    public static native void tick(long contextId, int key, Bitmap vram);
 
-    public static native void multipleTicks(long contextId, int[] key1, int[] key2, Bitmap vram);
+    public static native void multipleTicks(long contextId, int[] keys, Bitmap vram);
 
     public static native void reset(long contextId);
 }

--- a/library/src/main/java/com/suzukiplan/emulator/nes/core/NESKey.java
+++ b/library/src/main/java/com/suzukiplan/emulator/nes/core/NESKey.java
@@ -9,25 +9,37 @@ public class NESKey {
     private static final int MASK_DOWN = 32;
     private static final int MASK_LEFT = 64;
     private static final int MASK_RIGHT = 128;
+    public final Player player1 = new Player();
+    public final Player player2 = new Player();
 
-    public boolean up = false;
-    public boolean down = false;
-    public boolean left = false;
-    public boolean right = false;
-    public boolean a = false;
-    public boolean b = false;
-    public boolean select = false;
-    public boolean start = false;
+    public static class Player {
+        public boolean up = false;
+        public boolean down = false;
+        public boolean left = false;
+        public boolean right = false;
+        public boolean a = false;
+        public boolean b = false;
+        public boolean select = false;
+        public boolean start = false;
+    }
 
     public int getCode() {
-        int code = up ? MASK_UP : 0;
-        code += down ? MASK_DOWN : 0;
-        code += left ? MASK_LEFT : 0;
-        code += right ? MASK_RIGHT : 0;
-        code += a ? MASK_A : 0;
-        code += b ? MASK_B : 0;
-        code += select ? MASK_SELECT : 0;
-        code += start ? MASK_START : 0;
-        return code;
+        int code1 = player1.up ? MASK_UP : 0;
+        code1 += player1.down ? MASK_DOWN : 0;
+        code1 += player1.left ? MASK_LEFT : 0;
+        code1 += player1.right ? MASK_RIGHT : 0;
+        code1 += player1.a ? MASK_A : 0;
+        code1 += player1.b ? MASK_B : 0;
+        code1 += player1.select ? MASK_SELECT : 0;
+        code1 += player1.start ? MASK_START : 0;
+        int code2 = player2.up ? MASK_UP : 0;
+        code2 += player2.down ? MASK_DOWN : 0;
+        code2 += player2.left ? MASK_LEFT : 0;
+        code2 += player2.right ? MASK_RIGHT : 0;
+        code2 += player2.a ? MASK_A : 0;
+        code2 += player2.b ? MASK_B : 0;
+        code2 += player2.select ? MASK_SELECT : 0;
+        code2 += player2.start ? MASK_START : 0;
+        return code1 + code2 * 256;
     }
 }

--- a/library/src/main/java/com/suzukiplan/emulator/nes/core/NESView.java
+++ b/library/src/main/java/com/suzukiplan/emulator/nes/core/NESView.java
@@ -85,11 +85,11 @@ public class NESView extends SurfaceView implements SurfaceHolder.Callback {
         return Emulator.loadRom(context, rom);
     }
 
-    public void tick(int keyCodeP1, int keyCodeP2) {
+    public void tick(int keyCode) {
         if (null == context) return;
         // 1フレーム描画されるまでCPUを回す
         synchronized (locker) {
-            Emulator.tick(context, keyCodeP1, keyCodeP2, vram);
+            Emulator.tick(context, keyCode, vram);
         }
         // vramの内容をアスペクト比を保った状態で拡大しつつ画面に描画
         SurfaceHolder holder = getHolder();
@@ -111,11 +111,11 @@ public class NESView extends SurfaceView implements SurfaceHolder.Callback {
         holder.unlockCanvasAndPost(canvas);
     }
 
-    public void ticks(int[] keyCodeP1, int[] keyCodeP2) {
+    public void ticks(int[] keyCodes) {
         if (null == context) return;
         // nフレーム描画されるまでCPUを回す
         synchronized (locker) {
-            Emulator.multipleTicks(context, keyCodeP1, keyCodeP2, vram);
+            Emulator.multipleTicks(context, keyCodes, vram);
         }
         // vramの内容をアスペクト比を保った状態で拡大しつつ画面に描画
         SurfaceHolder holder = getHolder();

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -4,15 +4,12 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 26
 
-
-
     defaultConfig {
         applicationId "com.suzukiplan.emulator.nes.test"
         minSdkVersion 16
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }

--- a/test/src/main/java/com/suzukiplan/emulator/nes/test/MainActivity.kt
+++ b/test/src/main/java/com/suzukiplan/emulator/nes/test/MainActivity.kt
@@ -16,7 +16,7 @@ class MainActivity : AppCompatActivity() {
     private var nesView: NESView? = null
     private var tickThread: Thread? = null
     private var active = false
-    private val keyP1 = NESKey()
+    private val key = NESKey()
     private var speed = 1
 
     @SuppressLint("ShowToast")
@@ -42,14 +42,14 @@ class MainActivity : AppCompatActivity() {
         findViewById<View>(R.id.x6).setOnClickListener { speed = 6 }
         findViewById<View>(R.id.x7).setOnClickListener { speed = 7 }
         findViewById<View>(R.id.x8).setOnClickListener { speed = 8 }
-        findViewById<PushableTextView>(R.id.up).onPushChanged = { pushing -> keyP1.up = pushing }
-        findViewById<PushableTextView>(R.id.down).onPushChanged = { pushing -> keyP1.down = pushing }
-        findViewById<PushableTextView>(R.id.left).onPushChanged = { pushing -> keyP1.left = pushing }
-        findViewById<PushableTextView>(R.id.right).onPushChanged = { pushing -> keyP1.right = pushing }
-        findViewById<PushableTextView>(R.id.a).onPushChanged = { pushing -> keyP1.a = pushing }
-        findViewById<PushableTextView>(R.id.b).onPushChanged = { pushing -> keyP1.b = pushing }
-        findViewById<PushableTextView>(R.id.select).onPushChanged = { pushing -> keyP1.select = pushing }
-        findViewById<PushableTextView>(R.id.start).onPushChanged = { pushing -> keyP1.start = pushing }
+        findViewById<PushableTextView>(R.id.up).onPushChanged = { pushing -> key.player1.up = pushing }
+        findViewById<PushableTextView>(R.id.down).onPushChanged = { pushing -> key.player1.down = pushing }
+        findViewById<PushableTextView>(R.id.left).onPushChanged = { pushing -> key.player1.left = pushing }
+        findViewById<PushableTextView>(R.id.right).onPushChanged = { pushing -> key.player1.right = pushing }
+        findViewById<PushableTextView>(R.id.a).onPushChanged = { pushing -> key.player1.a = pushing }
+        findViewById<PushableTextView>(R.id.b).onPushChanged = { pushing -> key.player1.b = pushing }
+        findViewById<PushableTextView>(R.id.select).onPushChanged = { pushing -> key.player1.select = pushing }
+        findViewById<PushableTextView>(R.id.start).onPushChanged = { pushing -> key.player1.start = pushing }
 
         // start emulator
         nesView = findViewById(R.id.nes_view)
@@ -62,12 +62,11 @@ class MainActivity : AppCompatActivity() {
             while (active) {
                 val speed = this.speed
                 if (1 == speed) {
-                    nesView?.tick(keyP1.code, 0)
+                    nesView?.tick(key.code)
                 } else {
-                    val code = keyP1.code
-                    val codes1 = IntArray(speed, { _ -> code })
-                    val codes2 = IntArray(speed, { _ -> 0 })
-                    nesView?.ticks(codes1, codes2)
+                    val code = key.code
+                    val codes = IntArray(speed, { _ -> code })
+                    nesView?.ticks(codes)
                 }
             }
         }


### PR DESCRIPTION
`NESKey` と `NESView#tick` , `NESView#multipleTicks` のキーコードの仕様を変更します。

|class/method|従来|変更後|
|---|---|---|
|`NESKey`|player1と2を区別しない|プロパティでplayer1と2を区別|
|`NESView#tick`|引数にplayer1と2それぞれのkeyCodeを指定|1つの引数にplayer1と2のキーコードを指定|
|`NESView#multipleTicks`|（同上）|（同上）|

keyCode は, 下位8bitにplayer1の keyCode, 上位8bitにplayer2のkeyCodeを指定する仕様に変わりました。
これに伴い、NESView, NESKeyを使用するアプリケーションには, https://github.com/suzukiplan/nes-emulator-android/commit/8598e18e05510c22708097858c0ddd7014a224df と同等の修正が必要になります。
